### PR TITLE
return bool values in various methods to conform to the interface

### DIFF
--- a/src/SessionHandler/Cookie.php
+++ b/src/SessionHandler/Cookie.php
@@ -10,6 +10,8 @@ namespace SessionHandler;
  * http://php.net/manual/en/class.sessionhandlerinterface.php
  */
 
+use SessionHandler\Storage\HashMismatchException;
+
 class Cookie implements \SessionHandlerInterface {
 
   private $storage = null;
@@ -27,7 +29,7 @@ class Cookie implements \SessionHandlerInterface {
   
   /**
    * Set a custom storage handler
-   * @param Storage $storage storage handler
+   * @param Storage\SecureCookie $storage storage handler
    */
   public function setStorage($storage) {
     $this->storage = $storage;
@@ -49,6 +51,10 @@ class Cookie implements \SessionHandlerInterface {
       $data = $this->storage->get($session_id);
     } catch (HashMismatchException $ex) {
       $data = '';
+    } catch (\Exception $e) {
+      // not expected, but we need to make sure we return a string value
+      // in every case...
+      $data = '';
     }
 
     // Return the data, now that it's been verified.
@@ -62,7 +68,7 @@ class Cookie implements \SessionHandlerInterface {
    * @return bool write succeeded
    */
   public function write($session_id, $data) {
-    $this->storage->make($session_id, $data);
+    return $this->storage->make($session_id, $data);
   }
 
   /**
@@ -71,7 +77,7 @@ class Cookie implements \SessionHandlerInterface {
    * @return bool true success
    */
   public function destroy($session_id) {
-    $this->storage->forget($session_id);
+    return $this->storage->forget($session_id);
   }
 
   // In the context of cookies, these three methods are unneccessary, but must

--- a/src/SessionHandler/Cookie.php
+++ b/src/SessionHandler/Cookie.php
@@ -77,7 +77,9 @@ class Cookie implements \SessionHandlerInterface {
    * @return bool true success
    */
   public function destroy($session_id) {
-    return $this->storage->forget($session_id);
+    $resPhpSess = $this->storage->forget(session_name());
+    $resData = $this->storage->forget($session_id);
+    return $resPhpSess && $resData;
   }
 
   // In the context of cookies, these three methods are unneccessary, but must

--- a/src/SessionHandler/Storage/SecureCookie.php
+++ b/src/SessionHandler/Storage/SecureCookie.php
@@ -95,7 +95,6 @@ class SecureCookie
 
         // Set a cookie with the data
         $ttl = time() + ($minutes * 60);
-
         return setcookie($name, base64_encode($value), $ttl, $path, $domain, $secure, $httponly);
     }
 

--- a/src/SessionHandler/Storage/SecureCookie.php
+++ b/src/SessionHandler/Storage/SecureCookie.php
@@ -95,13 +95,9 @@ class SecureCookie
      * @param int|null $minutes If null, we set the value to `0` (which means the cookie lives
      *                          within this client session), otherwise the timestamp is calculated
      *                          as `current time + $minutes * 60`
-     * @param string|null $path
-     * @param string|null $domain
-     * @param bool $secure
-     * @param bool $httponly
      * @return bool
      */
-    public function make($name, $value, $minutes = null, $path = null, $domain = null, $secure = false, $httponly = true)
+    public function make($name, $value, $minutes = null)
     {
         // Calculate a hash for the data and append it to the end of the data string
         $hash = hash_hmac($this->hash_algo, $value, $this->hash_secret);
@@ -109,12 +105,12 @@ class SecureCookie
 
         // Set a cookie with the data
         $ttl = $minutes === null ? 0 : time() + ($minutes * 60);
-        return setcookie($name, base64_encode($value), $ttl, $path, $domain, $secure, $httponly);
+        return setcookie($name, base64_encode($value), $ttl, '/', null, null, true);
     }
 
     public function forget($name)
     {
-        return setcookie($name, '', time());
+        return setcookie($name, '', 1, '/');
     }
 
 }

--- a/src/SessionHandler/Storage/SecureCookie.php
+++ b/src/SessionHandler/Storage/SecureCookie.php
@@ -49,9 +49,9 @@ class SecureCookie
             return $default;
         }
 
-        $raw = base64_decode($_COOKIE["name"]);
+        $raw = base64_decode($_COOKIE[$name]);
 
-        // Cookie should be atleast the size of the hash length.
+        // Cookie should be at least the size of the hash length.
         // If it's not, we can just bail out
         if (strlen($raw) < $this->hash_len) {
             return $default;
@@ -87,14 +87,28 @@ class SecureCookie
         return isset($_COOKIE[$name]);
     }
 
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httponly = true)
+    /**
+     * Set cookie.
+     *
+     * @param string $name
+     * @param string $value
+     * @param int|null $minutes If null, we set the value to `0` (which means the cookie lives
+     *                          within this client session), otherwise the timestamp is calculated
+     *                          as `current time + $minutes * 60`
+     * @param string|null $path
+     * @param string|null $domain
+     * @param bool $secure
+     * @param bool $httponly
+     * @return bool
+     */
+    public function make($name, $value, $minutes = null, $path = null, $domain = null, $secure = false, $httponly = true)
     {
         // Calculate a hash for the data and append it to the end of the data string
         $hash = hash_hmac($this->hash_algo, $value, $this->hash_secret);
         $value .= $hash;
 
         // Set a cookie with the data
-        $ttl = time() + ($minutes * 60);
+        $ttl = $minutes === null ? 0 : time() + ($minutes * 60);
         return setcookie($name, base64_encode($value), $ttl, $path, $domain, $secure, $httponly);
     }
 


### PR DESCRIPTION
According to the docs, all the methods should return boolean "sucess/failure" values (except of `read`, which of course should return a string).

Additionally I've added a `use` statement to fix an otherwise wrong type hint.
