### PR TITLE
fix cookie expire date calculation; fix cookie access

### DIFF
--- a/src/SessionHandler/Storage/SecureCookie.php
+++ b/src/SessionHandler/Storage/SecureCookie.php
@@ -49,9 +49,9 @@ class SecureCookie
             return $default;
         }
 
-        $raw = base64_decode($_COOKIE["name"]);
+        $raw = base64_decode($_COOKIE[$name]);
 
-        // Cookie should be atleast the size of the hash length.
+        // Cookie should be at least the size of the hash length.
         // If it's not, we can just bail out
         if (strlen($raw) < $this->hash_len) {
             return $default;
@@ -87,15 +87,28 @@ class SecureCookie
         return isset($_COOKIE[$name]);
     }
 
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httponly = true)
+    /**
+     * Set cookie.
+     *
+     * @param string $name
+     * @param string $value
+     * @param int|null $minutes If null, we set the value to `0` (which means the cookie lives
+     *                          within this client session), otherwise the timestamp is calculated
+     *                          as `current time + $minutes * 60`
+     * @param string|null $path
+     * @param string|null $domain
+     * @param bool $secure
+     * @param bool $httponly
+     * @return bool
+     */
+    public function make($name, $value, $minutes = null, $path = null, $domain = null, $secure = false, $httponly = true)
     {
         // Calculate a hash for the data and append it to the end of the data string
         $hash = hash_hmac($this->hash_algo, $value, $this->hash_secret);
         $value .= $hash;
 
         // Set a cookie with the data
-        $ttl = time() + ($minutes * 60);
-
+        $ttl = $minutes === null ? 0 : time() + ($minutes * 60);
         return setcookie($name, base64_encode($value), $ttl, $path, $domain, $secure, $httponly);
     }
 


### PR DESCRIPTION
expire calculation: Allow for setting a value of `0` to the
`setcookie`'s `expire` parameter (which means expires with
the client session).

cookie access: fix wrong array index in
`\SessionHandler\Storage\SecureCookie::get`
