### PR TITLE
adds boolean returns to `write` and `destroy`

### DIFF
--- a/src/SessionHandler/Cookie.php
+++ b/src/SessionHandler/Cookie.php
@@ -63,6 +63,7 @@ class Cookie implements \SessionHandlerInterface {
    */
   public function write($session_id, $data) {
     $this->storage->make($session_id, $data);
+    return true;
   }
 
   /**
@@ -72,6 +73,7 @@ class Cookie implements \SessionHandlerInterface {
    */
   public function destroy($session_id) {
     $this->storage->forget($session_id);
+    return true;
   }
 
   // In the context of cookies, these three methods are unneccessary, but must


### PR DESCRIPTION
fixes #11 

One possible solution for the warning messages in logs described in #11 
following the example of Laravel https://github.com/laravel/framework/issues/15717